### PR TITLE
0.9 - Reduce scope and expect all configuration through TOML file

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -32,7 +32,8 @@ configurations {
 
 dependencies {
     // Static Analysis
-    compileOnly libs.nulls
+    api libs.annotations.jspecify
+    compileOnly libs.annotations.jetbrains
 
     // Git
     implementation libs.jgit

--- a/gitversion-cli/src/main/java/net/minecraftforge/gitver/cli/Main.java
+++ b/gitversion-cli/src/main/java/net/minecraftforge/gitver/cli/Main.java
@@ -129,7 +129,7 @@ public final class Main {
             } else if (options.has(jsonO)) {
                 result = version.toJson();
             } else {
-                result = version.getTagOffset();
+                result = version.get();
             }
 
             if (output != null)

--- a/settings.gradle
+++ b/settings.gradle
@@ -44,7 +44,8 @@ dependencyResolutionManagement {
         library 'slf4j', 'org.slf4j',          'slf4j-simple' version '1.7.36'
 
         // Static Analysis
-        library 'nulls', 'org.jetbrains', 'annotations' version '26.0.2'
+        library 'annotations-jspecify',  'org.jspecify',  'jspecify'    version '1.0.1'
+        library 'annotations-jetbrains', 'org.jetbrains', 'annotations' version '26.1.0'
     }
     //@formatter:on
 }

--- a/src/main/java/module-info.java
+++ b/src/main/java/module-info.java
@@ -2,6 +2,9 @@
  * Copyright (c) Forge Development LLC
  * SPDX-License-Identifier: LGPL-2.1-only
  */
+import org.jspecify.annotations.NullMarked;
+
+@NullMarked
 module net.minecraftforge.gitver {
     exports net.minecraftforge.gitver.api;
 
@@ -9,5 +12,6 @@ module net.minecraftforge.gitver {
     requires org.eclipse.jgit;
 
     requires com.google.gson;
+    requires transitive org.jspecify;
     requires static org.jetbrains.annotations;
 }

--- a/src/main/java/net/minecraftforge/gitver/api/GitVersion.java
+++ b/src/main/java/net/minecraftforge/gitver/api/GitVersion.java
@@ -6,21 +6,22 @@ package net.minecraftforge.gitver.api;
 
 import net.minecraftforge.gitver.internal.GitVersionImpl;
 import net.minecraftforge.gitver.internal.GitVersionInternal;
-import org.jetbrains.annotations.NotNullByDefault;
-import org.jetbrains.annotations.Nullable;
-import org.jetbrains.annotations.UnknownNullability;
 import org.jetbrains.annotations.Unmodifiable;
+import org.jspecify.annotations.NonNull;
+import org.jspecify.annotations.NullUnmarked;
+import org.jspecify.annotations.Nullable;
 
 import java.io.File;
 import java.io.Serializable;
 import java.util.Collection;
 import java.util.List;
+import java.util.function.Supplier;
 
 /**
  * The heart of the GitVersion library. Information about how GitVersion operates can be found on the
  * <a href="https://github.com/MinecraftForge/GitVersion">path page</a>.
  */
-public sealed interface GitVersion extends AutoCloseable permits GitVersionInternal {
+public sealed interface GitVersion extends Supplier<String>, AutoCloseable permits GitVersionInternal {
     /* BUILDER */
 
     /**
@@ -41,6 +42,7 @@ public sealed interface GitVersion extends AutoCloseable permits GitVersionInter
      * automatically from the project directory. If the git directory is not set, it will default to {@code .git} in the
      * root directory.
      */
+    @NullUnmarked
     sealed interface Builder permits GitVersionInternal.Builder {
         /**
          * Sets the git directory for the GitVersion instance. Ideally, this should be located in the root directory.
@@ -48,7 +50,7 @@ public sealed interface GitVersion extends AutoCloseable permits GitVersionInter
          * @param gitDir The git directory
          * @return This builder
          */
-        Builder gitDir(@UnknownNullability File gitDir);
+        Builder gitDir(File gitDir);
 
         /**
          * Sets the root directory for the GitVersion instance.
@@ -56,7 +58,7 @@ public sealed interface GitVersion extends AutoCloseable permits GitVersionInter
          * @param root The root directory
          * @return This builder
          */
-        Builder root(@UnknownNullability File root);
+        Builder root(File root);
 
         /**
          * Sets the project directory for the GitVersion instance.
@@ -64,9 +66,9 @@ public sealed interface GitVersion extends AutoCloseable permits GitVersionInter
          * @param project The project directory
          * @return This builder
          */
-        Builder project(@UnknownNullability File project);
+        Builder project(File project);
 
-        Builder config(@UnknownNullability File config);
+        Builder config(File config);
 
         /**
          * Sets the config to use for the GitVersion instance.
@@ -74,7 +76,7 @@ public sealed interface GitVersion extends AutoCloseable permits GitVersionInter
          * @param config The config
          * @return This builder
          */
-        Builder config(GitVersionConfig config);
+        Builder config(@NonNull GitVersionConfig config);
 
         Builder strict(boolean strict);
 
@@ -95,55 +97,17 @@ public sealed interface GitVersion extends AutoCloseable permits GitVersionInter
 
     /**
      * Calculates a version number in the form
-     * <code>{@link GitVersionImpl.Info#getTag() tag}.{@link GitVersionImpl.Info#getOffset() offset}</code>.
+     * <code>{@link GitVersionImpl.Info#getTag() tag}.{@link GitVersionImpl.Info#getOffset() offset}</code>. The default
+     * GitVersion implementation will cache this version after it has been first queried.
      * <p>
-     * For example, if your current tag is {@code 1.0} and 5 commits have been made since the tagged commit, then the
-     * resulting version number will be {@code 1.0.5}.
+     * If the {@code .gitversion.toml} config specifies branches, the current branch must match that within the branches
+     * String array (or it must be a detached HEAD). If it doesn't match, <code>-{@link Info#getBranch(boolean) branch}</code>
+     * will be appended to the version number.
      *
-     * @return The calculated version
+     * @return The calculated version number.
      */
-    String getTagOffset();
-
-    /** @see #getTagOffsetBranch(Collection) */
-    String getTagOffsetBranch();
-
-    /** @see #getTagOffsetBranch(Collection) */
-    String getTagOffsetBranch(@UnknownNullability String... allowedBranches);
-
-    /**
-     * Calculates a version number using {@link #getTagOffset()}. If the current branch is not included in the defined
-     * list of allowed branches, it will be appended to the version number. It is important to note that any instances
-     * of the forward-slash character ({@code /}) will be replaced with a hyphen ({@code -}).
-     * <p>
-     * For example, if your current tag is {@code 2.3}, 6 commits have been made since the tagged commit, and you are on
-     * a branch named {@literal "feature/cool-stuff"}, then the resulting version number will be
-     * {@code 2.3.6-feature-cool-stuff}.
-     *
-     * @param allowedBranches A list of allowed branches; the current branch is appended if not in this list
-     * @return The calculated version
-     * @see #getTagOffset()
-     */
-    String getTagOffsetBranch(@UnknownNullability Collection<String> allowedBranches);
-
-    /** @see #getMCTagOffsetBranch(String, Collection) */
-    String getMCTagOffsetBranch(@UnknownNullability String mcVersion);
-
-    /** @see #getMCTagOffsetBranch(String, Collection) */
-    String getMCTagOffsetBranch(String mcVersion, String... allowedBranches);
-
-    /**
-     * Calculates a version number using {@link #getTagOffsetBranch(String...)}, additionally prepending the given
-     * Minecraft version.
-     * <p>
-     * For example, if your current tag is {@code 5.0}, 2 commits have been made since the tagged commit, you are on a
-     * branch named {@literal "master"} which is included in the allowed branches, and the given Minecraft version is
-     * {@code 1.21.4}, then the resulting version number will be {@code 1.21.4-5.0.2}.
-     *
-     * @param mcVersion       The minecraft version
-     * @param allowedBranches A list of allowed branches
-     * @return The calculated version
-     */
-    String getMCTagOffsetBranch(String mcVersion, Collection<String> allowedBranches);
+    @Override
+    String get();
 
 
     /* CHANGELOG */
@@ -190,8 +154,10 @@ public sealed interface GitVersion extends AutoCloseable permits GitVersionInter
      * Represents information about a git repository. This can be used to access other information when the standard
      * versioning methods in {@link GitVersion} do not suffice.
      */
-    @NotNullByDefault
     sealed interface Info extends Serializable permits GitVersionInternal.Info {
+        /** @return The calculated version */
+        String getVersion();
+
         /** @return The current tag as described by the Git repository using the applied filters */
         String getTag();
 
@@ -238,6 +204,8 @@ public sealed interface GitVersion extends AutoCloseable permits GitVersionInter
 
     /** @return The tag prefix used when filtering tags */
     String getTagPrefix();
+
+    @Unmodifiable Collection<String> getBranches();
 
     /** @return The filters used when filtering tags (excluding the {@linkplain #getTagPrefix() tag prefix}) */
     @Unmodifiable Collection<String> getFilters();

--- a/src/main/java/net/minecraftforge/gitver/api/GitVersionConfig.java
+++ b/src/main/java/net/minecraftforge/gitver/api/GitVersionConfig.java
@@ -5,8 +5,10 @@
 package net.minecraftforge.gitver.api;
 
 import net.minecraftforge.gitver.internal.GitVersionConfigInternal;
-import org.jetbrains.annotations.Nullable;
-import org.jetbrains.annotations.UnknownNullability;
+import org.jspecify.annotations.NonNull;
+import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.NullUnmarked;
+import org.jspecify.annotations.Nullable;
 import org.tomlj.Toml;
 
 import java.io.File;
@@ -19,6 +21,7 @@ import java.util.List;
  *
  * @see Project
  */
+@NullUnmarked
 public sealed interface GitVersionConfig permits GitVersionConfigInternal {
     /**
      * Gets the project at the given path.
@@ -29,7 +32,7 @@ public sealed interface GitVersionConfig permits GitVersionConfigInternal {
     @Nullable Project getProject(@Nullable String path);
 
     /** @return All projects, including the root project. */
-    Collection<Project> getAllProjects();
+    @NonNull Collection<Project> getAllProjects();
 
     /**
      * Validates this configuration by ensuring that all declared subprojects exist from the given root.
@@ -37,10 +40,10 @@ public sealed interface GitVersionConfig permits GitVersionConfigInternal {
      * @param root The root to validate from
      * @throws IllegalArgumentException If a subproject path does not exist
      */
-    void validate(@UnknownNullability File root) throws IllegalArgumentException;
+    void validate(File root) throws IllegalArgumentException;
 
     /** @return Any errors made during the config TOML parsing */
-    List<? extends RuntimeException> errors();
+    @NonNull List<? extends RuntimeException> errors();
 
     /**
      * Attempts to parse the given config file into a {@link GitVersionConfig} using {@linkplain Toml TOMLJ}. If it
@@ -49,12 +52,15 @@ public sealed interface GitVersionConfig permits GitVersionConfigInternal {
      * @param config The config file
      * @return The parsed config, or an empty config if the file does not exist
      */
-    static GitVersionConfig parse(@UnknownNullability File config) {
+    static @NonNull GitVersionConfig parse(File config) {
         return GitVersionConfigInternal.parse(config);
     }
 
+    @NullMarked
     sealed interface Project permits GitVersionConfigInternal.Project {
         String getPath();
+
+        String[] getBranches();
 
         String[] getIncludePaths();
 

--- a/src/main/java/net/minecraftforge/gitver/api/package-info.java
+++ b/src/main/java/net/minecraftforge/gitver/api/package-info.java
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: LGPL-2.1-only
  */
 // TODO [Git Version] Documentation
-@NotNullByDefault
+@NullMarked
 package net.minecraftforge.gitver.api;
 
-import org.jetbrains.annotations.NotNullByDefault;
+import org.jspecify.annotations.NullMarked;

--- a/src/main/java/net/minecraftforge/gitver/internal/GitChangelog.java
+++ b/src/main/java/net/minecraftforge/gitver/internal/GitChangelog.java
@@ -7,10 +7,9 @@ package net.minecraftforge.gitver.internal;
 import org.eclipse.jgit.api.Git;
 import org.eclipse.jgit.api.errors.GitAPIException;
 import org.eclipse.jgit.revwalk.RevCommit;
-import org.jetbrains.annotations.Nullable;
+import org.jspecify.annotations.Nullable;
 
 import java.io.IOException;
-import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.Objects;

--- a/src/main/java/net/minecraftforge/gitver/internal/GitUtils.java
+++ b/src/main/java/net/minecraftforge/gitver/internal/GitUtils.java
@@ -19,7 +19,7 @@ import org.eclipse.jgit.revwalk.filter.OrRevFilter;
 import org.eclipse.jgit.revwalk.filter.RevFilter;
 import org.eclipse.jgit.transport.RemoteConfig;
 import org.eclipse.jgit.util.StringUtils;
-import org.jetbrains.annotations.Nullable;
+import org.jspecify.annotations.Nullable;
 
 import java.io.File;
 import java.io.IOException;

--- a/src/main/java/net/minecraftforge/gitver/internal/GitVersionConfigImpl.java
+++ b/src/main/java/net/minecraftforge/gitver/internal/GitVersionConfigImpl.java
@@ -5,9 +5,9 @@
 package net.minecraftforge.gitver.internal;
 
 import net.minecraftforge.gitver.api.GitVersionConfig;
-import org.jetbrains.annotations.NotNullByDefault;
-import org.jetbrains.annotations.Nullable;
-import org.jetbrains.annotations.UnknownNullability;
+import org.jspecify.annotations.NonNull;
+import org.jspecify.annotations.NullUnmarked;
+import org.jspecify.annotations.Nullable;
 import org.tomlj.Toml;
 import org.tomlj.TomlParseResult;
 import org.tomlj.TomlTable;
@@ -23,7 +23,6 @@ import java.util.Objects;
 import java.util.function.Predicate;
 import java.util.function.Supplier;
 
-@NotNullByDefault
 public record GitVersionConfigImpl(
     Map<String, GitVersionConfig.Project> projects,
     @Override List<? extends RuntimeException> errors
@@ -31,7 +30,7 @@ public record GitVersionConfigImpl(
     static final GitVersionConfig EMPTY = new Empty();
 
     @Override
-    public @Nullable GitVersionConfig.Project getProject(@Nullable String path) {
+    public GitVersionConfig.@Nullable Project getProject(@Nullable String path) {
         return this.projects.get(path);
     }
 
@@ -48,7 +47,7 @@ public record GitVersionConfigImpl(
         }
     }
 
-    public static GitVersionConfig parse(@UnknownNullability File config) throws IOException {
+    public static GitVersionConfig parse(@Nullable File config) throws IOException {
         if (config == null || !config.exists()) return EMPTY;
 
         var toml = Toml.parse(config.toPath(), TomlVersion.V1_0_0);
@@ -71,12 +70,13 @@ public record GitVersionConfigImpl(
 
     public record ProjectImpl(
         @Override String getPath,
+        @Override String[] getBranches,
         @Override String[] getIncludePaths,
         @Override String[] getExcludePaths,
         @Override String getTagPrefix,
         @Override String[] getFilters
     ) implements GitVersionConfigInternal.Project {
-        private static final ProjectImpl DEFAULT_ROOT = new ProjectImpl("", new String[0], new String[0], "", new String[0]);
+        private static final ProjectImpl DEFAULT_ROOT = new ProjectImpl("", new String[0], new String[0], new String[0], "", new String[0]);
         private static final List<GitVersionConfig.Project> DEFAULT_ROOT_LIST = List.of(DEFAULT_ROOT);
 
         private static String getString(TomlTable table, String key) {
@@ -95,20 +95,22 @@ public record GitVersionConfigImpl(
             var root = toml.getTableOrEmpty("root");
             if (root.isEmpty()) return DEFAULT_ROOT;
 
+            var allowedBranches = getStringArray(root, "branches");
             var includePaths = getStringArray(root, "include");
             var excludePaths = getStringArray(root, "exclude");
             var tagPrefix = getString(root, "tag");
             var filters = getStringArray(root, "filters");
-            return new ProjectImpl("", includePaths, excludePaths, tagPrefix, filters);
+            return new ProjectImpl("", allowedBranches, includePaths, excludePaths, tagPrefix, filters);
         }
 
         private static GitVersionConfig.Project parse(String key, TomlTable table) {
             var project = Objects.requireNonNullElse(table.getString("path"), key);
+            var allowedBranches = getStringArray(table, "branches");
             var includePaths = getStringArray(table, "include");
             var excludePaths = getStringArray(table, "exclude");
             var tagPrefix = getString(table, "tag", () -> project.replace("/", "-"));
             var filters = getStringArray(table, "filters");
-            return new ProjectImpl(project, includePaths, excludePaths, tagPrefix, filters);
+            return new ProjectImpl(project, allowedBranches, includePaths, excludePaths, tagPrefix, filters);
         }
 
         @Override
@@ -122,6 +124,7 @@ public record GitVersionConfigImpl(
         }
     }
 
+    @NullUnmarked
     public static final class Empty implements GitVersionConfigInternal {
         private Empty() { }
 
@@ -131,15 +134,15 @@ public record GitVersionConfigImpl(
         }
 
         @Override
-        public Collection<GitVersionConfig.Project> getAllProjects() {
+        public @NonNull Collection<GitVersionConfig.Project> getAllProjects() {
             return ProjectImpl.DEFAULT_ROOT_LIST;
         }
 
         @Override
-        public void validate(@UnknownNullability File root) { }
+        public void validate(File root) { }
 
         @Override
-        public List<? extends RuntimeException> errors() {
+        public @NonNull List<? extends RuntimeException> errors() {
             return List.of();
         }
     }

--- a/src/main/java/net/minecraftforge/gitver/internal/GitVersionConfigInternal.java
+++ b/src/main/java/net/minecraftforge/gitver/internal/GitVersionConfigInternal.java
@@ -5,13 +5,15 @@
 package net.minecraftforge.gitver.internal;
 
 import net.minecraftforge.gitver.api.GitVersionConfig;
-import org.jetbrains.annotations.UnknownNullability;
+import org.jspecify.annotations.NonNull;
+import org.jspecify.annotations.NullUnmarked;
 
 import java.io.File;
 import java.io.IOException;
 
+@NullUnmarked
 public non-sealed interface GitVersionConfigInternal extends GitVersionConfig {
-    static GitVersionConfig parse(@UnknownNullability File config) {
+    static @NonNull GitVersionConfig parse(File config) {
         try {
             return GitVersionConfigImpl.parse(config);
         } catch (IOException e) {

--- a/src/main/java/net/minecraftforge/gitver/internal/GitVersionImpl.java
+++ b/src/main/java/net/minecraftforge/gitver/internal/GitVersionImpl.java
@@ -15,7 +15,7 @@ import org.eclipse.jgit.lib.ObjectId;
 import org.eclipse.jgit.lib.Repository;
 import org.eclipse.jgit.revwalk.RevCommit;
 import org.eclipse.jgit.util.StringUtils;
-import org.jetbrains.annotations.Nullable;
+import org.jspecify.annotations.Nullable;
 import org.jetbrains.annotations.Unmodifiable;
 
 import java.io.File;
@@ -47,6 +47,7 @@ public final class GitVersionImpl implements GitVersionInternal {
 
     // Config
     // NOTE: These are not calculated lazily because they are used in both info gen and changelog gen
+    private final List<String> branches;
     private final List<File> includes;
     private final List<File> excludes;
     private final String tagPrefix;
@@ -83,6 +84,7 @@ public final class GitVersionImpl implements GitVersionInternal {
         this.localPath = GitVersionInternal.super.getProjectPath();
         var projectConfig = Objects.requireNonNull(config.getProject(this.localPath));
 
+        this.branches = List.of(projectConfig.getBranches());
         this.includesPaths = makePaths(this.includes = parsePaths(Arrays.asList(projectConfig.getIncludePaths()), false));
         this.excludesPaths = makePaths(this.excludes = parsePaths(Arrays.asList(projectConfig.getExcludePaths()), true));
         this.tagPrefix = this.makeTagPrefix(projectConfig.getTagPrefix());
@@ -99,6 +101,12 @@ public final class GitVersionImpl implements GitVersionInternal {
         this.allExcludingPaths = allExcludingPaths;
     }
 
+    /* VERSIONING */
+
+    @Override
+    public String get() {
+        return this.getInfo().getVersion();
+    }
 
     /* CHANGELOG */
 
@@ -139,7 +147,8 @@ public final class GitVersionImpl implements GitVersionInternal {
 
     @Override
     public @Nullable String getUrl() {
-        return this.url.get();
+        var url = this.url.get();
+        return url.isEmpty() ? null : url;
     }
 
     private ObjectId resolve(String ref) {
@@ -200,11 +209,11 @@ public final class GitVersionImpl implements GitVersionInternal {
 
             var offset = commitCountProvider.getAsString(this.git, desc[0], desc[1], this.strict);
             var hash = desc[2]; // Technically this has a 'g' prefix but its been around for so long I don't really care
-            var branch = longBranch != null ? Repository.shortenRefName(longBranch) : null;
+            var branch = longBranch != null ? Repository.shortenRefName(longBranch) : "HEAD";
             var commit = ObjectId.toString(commitId);
             var abbreviatedId = commitId.abbreviate(8).name();
 
-            return new Info(tag, offset, hash, branch, commit, abbreviatedId);
+            return Info.of(tag, offset, hash, branch, commit, abbreviatedId, this.branches);
         } catch (Exception e) {
             if (this.strict) throw new GitVersionExceptionInternal("Failed to calculate version info", e);
 
@@ -213,18 +222,20 @@ public final class GitVersionImpl implements GitVersionInternal {
     }
 
     /** @see #url */
-    private @Nullable String calculateUrl() {
+    private String calculateUrl() {
         try {
             this.open();
 
-            return GitUtils.buildProjectUrl(this.git);
+            var url = GitUtils.buildProjectUrl(this.git);
+            return url == null ? "" : url;
         } catch (Exception e) {
-            return null;
+            return "";
         }
     }
 
     /** @see GitVersion.Info */
     public record Info(
+        String getVersion,
         String getTag,
         String getOffset,
         String getHash,
@@ -232,7 +243,27 @@ public final class GitVersionImpl implements GitVersionInternal {
         String getCommit,
         String getAbbreviatedId
     ) implements GitVersionInternal.Info {
-        private static final Info EMPTY = new Info("0.0", "0", "00000000", "master", "0000000000000000000000", "00000000");
+        private static final Info EMPTY = new Info("0.0.0", "0.0", "0", "00000000", "master", "0000000000000000000000", "00000000");
+
+        private static Info of(
+            String tag,
+            String offset,
+            String hash,
+            String branch,
+            String commit,
+            String abbreviatedId,
+            List<String> allowedBranches
+        ) {
+            var version = new StringBuilder().append(tag).append('.').append(offset);
+
+            if (!allowedBranches.isEmpty()) {
+                // branch is already non version friendly
+                if (StringUtils.isEmptyOrNull(branch) || "HEAD".equals(branch) || !allowedBranches.contains(branch))
+                    version.append('-').append(GitVersionInternal.Info.getBranch(branch, true));
+            }
+
+            return new Info(version.toString(), tag, offset, hash, branch, commit, abbreviatedId);
+        }
     }
 
 
@@ -249,6 +280,11 @@ public final class GitVersionImpl implements GitVersionInternal {
             return "";
 
         return !tagPrefix.endsWith("-") ? tagPrefix + "-" : tagPrefix;
+    }
+
+    @Override
+    public @Unmodifiable Collection<String> getBranches() {
+        return this.branches;
     }
 
     @Override
@@ -403,6 +439,11 @@ public final class GitVersionImpl implements GitVersionInternal {
 
     public record Empty(@Nullable File project) implements GitVersionInternal {
         @Override
+        public String get() {
+            return "0.0.0";
+        }
+
+        @Override
         public String generateChangelog(@Nullable String start, @Nullable String url, boolean plainText) throws GitVersionException {
             throw new GitVersionExceptionInternal("Cannot generate a changelog without a repository");
         }
@@ -443,6 +484,11 @@ public final class GitVersionImpl implements GitVersionInternal {
                 return this.project;
 
             throw new GitVersionExceptionInternal("Cannot get project directory without a project");
+        }
+
+        @Override
+        public @Unmodifiable Collection<String> getBranches() {
+            throw new GitVersionExceptionInternal("Cannot get allowed branches from an empty repository");
         }
 
         @Override public @Unmodifiable Collection<File> getIncludes() {

--- a/src/main/java/net/minecraftforge/gitver/internal/GitVersionInternal.java
+++ b/src/main/java/net/minecraftforge/gitver/internal/GitVersionInternal.java
@@ -7,19 +7,15 @@ package net.minecraftforge.gitver.internal;
 import net.minecraftforge.gitver.api.GitVersion;
 import net.minecraftforge.gitver.api.GitVersionConfig;
 import net.minecraftforge.gitver.api.GitVersionException;
-import org.eclipse.jgit.util.StringUtils;
-import org.jetbrains.annotations.NotNullByDefault;
-import org.jetbrains.annotations.Nullable;
-import org.jetbrains.annotations.UnknownNullability;
+import org.jspecify.annotations.NonNull;
+import org.jspecify.annotations.NullUnmarked;
+import org.jspecify.annotations.Nullable;
 import org.jetbrains.annotations.Unmodifiable;
 
 import java.io.File;
-import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
 
-@NotNullByDefault
 public non-sealed interface GitVersionInternal extends GitVersion {
     List<String> DEFAULT_ALLOWED_BRANCHES = List.of("master", "main", "HEAD");
     /* BUILDER */
@@ -28,6 +24,7 @@ public non-sealed interface GitVersionInternal extends GitVersion {
         return new Builder();
     }
 
+    @NullUnmarked
     final class Builder implements GitVersion.Builder {
         private @Nullable File gitDir;
         private @Nullable File root;
@@ -39,31 +36,31 @@ public non-sealed interface GitVersionInternal extends GitVersion {
         private Builder() { }
 
         @Override
-        public GitVersion.Builder gitDir(@UnknownNullability File gitDir) {
+        public GitVersion.Builder gitDir(File gitDir) {
             this.gitDir = gitDir;
             return this;
         }
 
         @Override
-        public GitVersion.Builder root(@UnknownNullability File root) {
+        public GitVersion.Builder root(File root) {
             this.root = root != null ? root.getAbsoluteFile() : null;
             return this;
         }
 
         @Override
-        public GitVersion.Builder project(@UnknownNullability File project) {
+        public GitVersion.Builder project(File project) {
             this.project = project != null ? project.getAbsoluteFile() : null;
             return this;
         }
 
         @Override
-        public GitVersion.Builder config(@UnknownNullability File config) {
+        public GitVersion.Builder config(File config) {
             this.config = config != null ? GitVersionConfig.parse(config) : null;
             return this;
         }
 
         @Override
-        public GitVersion.Builder config(GitVersionConfig config) {
+        public GitVersion.Builder config(@NonNull GitVersionConfig config) {
             this.config = config;
             return this;
         }
@@ -118,70 +115,19 @@ public non-sealed interface GitVersionInternal extends GitVersion {
     }
 
 
-    /* VERSIONING */
-
-    @Override
-    default String getTagOffset() {
-        var info = this.getInfo();
-        return "%s.%s".formatted(info.getTag(), info.getOffset());
-    }
-
-    @Override
-    default String getTagOffsetBranch() {
-        return this.getTagOffsetBranch(DEFAULT_ALLOWED_BRANCHES);
-    }
-
-    @Override
-    default String getTagOffsetBranch(@UnknownNullability String... allowedBranches) {
-        return this.getTagOffsetBranch(Arrays.asList(Util.ensure(allowedBranches)));
-    }
-
-    @Override
-    default String getTagOffsetBranch(@UnknownNullability Collection<String> allowedBranches) {
-        allowedBranches = Util.ensure(allowedBranches);
-        var version = this.getTagOffset();
-        if (allowedBranches.isEmpty()) return version;
-
-        var branch = this.getInfo().getBranch(true);
-        return StringUtils.isEmptyOrNull(branch) || allowedBranches.contains(branch) ? version : "%s-%s".formatted(version, branch);
-    }
-
-    @Override
-    default String getMCTagOffsetBranch(@UnknownNullability String mcVersion) {
-        if (StringUtils.isEmptyOrNull(mcVersion))
-            return this.getTagOffsetBranch();
-
-        var allowedBranches = new ArrayList<>(DEFAULT_ALLOWED_BRANCHES);
-        allowedBranches.add(mcVersion);
-        allowedBranches.add(mcVersion + ".0");
-        allowedBranches.add(mcVersion + ".x");
-        allowedBranches.add(mcVersion.substring(0, mcVersion.lastIndexOf('.')) + ".x");
-
-        return this.getMCTagOffsetBranch(mcVersion, allowedBranches);
-    }
-
-    @Override
-    default String getMCTagOffsetBranch(String mcVersion, String... allowedBranches) {
-        return this.getMCTagOffsetBranch(mcVersion, Arrays.asList(allowedBranches));
-    }
-
-    @Override
-    default String getMCTagOffsetBranch(String mcVersion, Collection<String> allowedBranches) {
-        return "%s-%s".formatted(mcVersion, this.getTagOffsetBranch(allowedBranches));
-    }
-
-
     /* INFO */
 
     /**
      * Represents information about a git repository. This can be used to access other information when the standard
      * versioning methods in {@link GitVersion} do not suffice.
      */
-    @NotNullByDefault
     non-sealed interface Info extends GitVersion.Info {
         @Override
         default String getBranch(boolean versionFriendly) {
-            var branch = this.getBranch();
+            return getBranch(this.getBranch(), versionFriendly);
+        }
+
+        static String getBranch(String branch, boolean versionFriendly) {
             if (!versionFriendly || branch.isBlank()) return branch;
 
             if (branch.startsWith("pulls/"))

--- a/src/main/java/net/minecraftforge/gitver/internal/Lazy.java
+++ b/src/main/java/net/minecraftforge/gitver/internal/Lazy.java
@@ -4,7 +4,7 @@
  */
 package net.minecraftforge.gitver.internal;
 
-import org.jetbrains.annotations.Nullable;
+import org.jspecify.annotations.Nullable;
 
 import java.util.function.Consumer;
 import java.util.function.Supplier;

--- a/src/main/java/net/minecraftforge/gitver/internal/Util.java
+++ b/src/main/java/net/minecraftforge/gitver/internal/Util.java
@@ -8,7 +8,8 @@ import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 import com.google.gson.ToNumberPolicy;
 import com.google.gson.stream.JsonReader;
-import org.jetbrains.annotations.Nullable;
+import org.jspecify.annotations.Nullable;
+import org.jspecify.annotations.NullUnmarked;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -22,6 +23,7 @@ import java.util.function.Predicate;
 import java.util.function.Supplier;
 import java.util.function.UnaryOperator;
 
+@NullUnmarked
 final class Util {
     /**
      * Hacky method to throw a checked exception without declaring it.

--- a/src/main/java/net/minecraftforge/gitver/internal/package-info.java
+++ b/src/main/java/net/minecraftforge/gitver/internal/package-info.java
@@ -1,0 +1,8 @@
+/*
+ * Copyright (c) Forge Development LLC
+ * SPDX-License-Identifier: LGPL-2.1-only
+ */
+@NullMarked
+package net.minecraftforge.gitver.internal;
+
+import org.jspecify.annotations.NullMarked;


### PR DESCRIPTION
This PR changes the way Git Version behaves to lean more towards the `.gitversion.toml` configuration file. This includes removing the various `getTagOffset()`, `getTagOffsetBranch()`, etc. methods from Git Version and making the Git Version process return a single, unchanging version number based on the config.

This means adding to the TOML spec. As of writing this draft PR, I have added "branches" to the TOML spec, which effectively acts as the replacement for "allowed branches" in `getTagOffsetBranch()` (which is now removed). Additionally, I have completely removed any and all Minecraft version number logic. The only project of ours to have special handling for Minecraft versions is Forge, so that logic can be done in Forge's buildscript itself. This helps to reduce Git Version's overall scope.

### Remaining Work
- [x] Serialize the version as part of `GitVersion.Info` for use in Gradle.
- [ ] Finish incomplete JavaDocs (there are not that many).

Open to suggestions on what else to add to this PR since it's gutting so much out anyway. Naturally, this will incur breaking changes on Git Version, Git Version Gradle, and Changelog Gradle.